### PR TITLE
update gitignore to ignore different versions of pwned passwords list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,4 @@ venv.bak/
 test_code/
 
 # Passwords file 
-pwned-passwords-sha1-ordered-by-hash-v4.txt
+pwned-passwords-sha1-ordered-by-hash-v*


### PR DESCRIPTION
Problem:
The old gitignore only ignores version 4 of the pwned passwords list. The actual list you can download is version 5.

Solution:
I update the gitignore with a joker (*) for the version number, so it ignores all versions now.